### PR TITLE
Code refactor

### DIFF
--- a/docker-service.sh
+++ b/docker-service.sh
@@ -32,7 +32,7 @@
 #
 # wsl -d Ubuntu ~/bin/docker-service Ubuntu
 
-[ -z $1 ] && DOCKER_DISTRO="" || DOCKER_DISTRO="-d $1"
+[ -z "$1" ] && DOCKER_DISTRO="$WSL_DISTRO_NAME" || DOCKER_DISTRO="$1"
 # If embedding this in .bashrc, .profile, .zshenv, or the like, remove the above line
 # and set $DOCKER_DISTRO to an empty string or something like this:
 # DOCKER_DISTRO="-d Ubuntu"
@@ -40,8 +40,7 @@ DOCKER_DIR=/mnt/wsl/shared-docker
 DOCKER_SOCK="$DOCKER_DIR/docker.sock"
 export DOCKER_HOST="unix://$DOCKER_SOCK"
 if [ ! -S "$DOCKER_SOCK" ]; then
-    mkdir -pm o=,ug=rw "$DOCKER_DIR"
+    mkdir -pm o=,ug=rwx "$DOCKER_DIR"
     chgrp docker "$DOCKER_DIR"
-    /mnt/c/Windows/System32/wsl.exe $DOCKER_DISTRO sh -c "nohup sudo -b dockerd < /dev/null > $DOCKER_DIR/dockerd.log 2>&1"
+    /mnt/c/Windows/System32/wsl.exe -d $DOCKER_DISTRO sh -c "nohup sudo -b dockerd < /dev/null > $DOCKER_DIR/dockerd.log 2>&1"
 fi
-


### PR DESCRIPTION
First of all, thank you for making these codes! Now WSL users do not need to use Docker Desktop for managing their docker containers.

I found missing `x` in `mkdir` line, after I encounter an error after using `docker-service.sh`.
https://github.com/bowmanjd/docker-wsl/blob/21335adc59f223c24edbb4adb2c3f4a0716c8aff/docker-service.sh#L43
I also add default value for `DOCKER_DISTRO` variable to `WSL_DISTRO_NAME` so that user can use that script without the need to specify their docker distro manually in the code if they want to use the script in `.bashrc` or other shell init file.

Let me know if there is something that should I add or revise.