### PR TITLE
This adds some more ubuntu/WSL2 support 

### DIFF
--- a/setup-docker.sh
+++ b/setup-docker.sh
@@ -220,6 +220,7 @@ if ! grep -q '/mnt/wsl' "/etc/docker/daemon.json" ; then
     cat "/etc/docker/daemon.json"
   fi
   confirm && echo "$DOCKERD_CONFIG" | $SUDO tee "/etc/docker/daemon.json"
+  $SUDO chgrp docker "/etc/docker/daemon.json"
 fi
 
 HOMEDIR=$(getent passwd | grep -w "$USERNAME" | cut -d: -f6)
@@ -232,7 +233,7 @@ DOCKER_DIR=/mnt/wsl/shared-docker
 DOCKER_SOCK="$DOCKER_DIR/docker.sock"
 export DOCKER_HOST="unix://$DOCKER_SOCK"
 if [ ! -S "$DOCKER_SOCK" ]; then
-    mkdir -pm o=,ug=rwx "$DOCKER_DIR"
+    sudo mkdir -pm o=,ug=rwx "$DOCKER_DIR"
     sudo chgrp docker "$DOCKER_DIR"
     "${WIN_ROOT}"c/Windows/System32/wsl.exe -d $DOCKER_DISTRO sh -c "nohup sudo -b dockerd < /dev/null > $DOCKER_DIR/dockerd.log 2>&1"
 fi

--- a/setup-docker.sh
+++ b/setup-docker.sh
@@ -105,13 +105,13 @@ if confirm ; then
        $SUDO dnf install dnf-plugins-core sudo passwd cracklib-dicts
        $SUDO dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
        $SUDO dnf install docker-ce docker-ce-cli containerd.io
-       
      ;;
-     "debian|ubuntu") $SUDO apt-get update
+     "debian"|"ubuntu") $SUDO apt-get update
        $SUDO apt-get upgrade -y
        $SUDO apt-get remove -y docker docker-engine docker.io containerd runc
        $SUDO apt-get install -y --no-install-recommends apt-transport-https ca-certificates curl gnupg2 sudo passwd
-       echo "deb [arch=amd64] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" | $SUDO tee /etc/apt/sources.list.d/docker.list
+       curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+       echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" | $SUDO tee /etc/apt/sources.list.d/docker.list
        $SUDO apt update
        $SUDO apt install docker-ce docker-ce-cli containerd.io
      ;;


### PR DESCRIPTION
These changes support then following:
- Installation of GPG key for installation of docker packages
- Cope with changes to mount path in /etc/wsl.conf
- Ensure newlines are added when writing /etc/docker/daemon.json

